### PR TITLE
Add helpful dev script guidance for package servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "ci:lint": "prettier --check '**/*.{js,jsx,ts,tsx}'",
     "lint:fix": "prettier --write '**/*.{js,jsx,ts,tsx}'",
     "update-npm-dependency": "zx ./scripts/update-npm-dependency.mjs",
-    "g:changeset": "changeset"
+    "g:changeset": "changeset",
+    "dev": "echo \"Please run dev server for a specific package. For example:\n - yarn workspace @snippet/next-app-dir dev\n - yarn workspace @snippet/next-app-dir-client dev\n - yarn workspace @e2e/next-app-dir dev\n - yarn workspace @e2e/next-app-dir-client dev\n - yarn workspace @e2e/gen1-next dev\""
   },
   "engines": {
     "yarn": ">= 3.0.0"


### PR DESCRIPTION
Adds a new `dev` script to package.json that provides clear guidance on how to run development servers for specific packages.

The script outputs example commands for running dev servers in various packages:
- @snippet/next-app-dir
- @snippet/next-app-dir-client
- @e2e/next-app-dir
- @e2e/next-app-dir-client
- @e2e/gen1-next

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=quantum-oasis&projectId=9206e169ee254b55a3a9abf4cef99167)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9206e169ee254b55a3a9abf4cef99167</projectId>-->