### PR TITLE
Harden gh-pages publish command execution

### DIFF
--- a/packages/fiddle/tools/gh-pages-publish.ts
+++ b/packages/fiddle/tools/gh-pages-publish.ts
@@ -1,4 +1,5 @@
 const { cd, exec, echo, touch } = require('shelljs');
+const { execFileSync } = require('child_process');
 const { readFileSync } = require('fs');
 const url = require('url');
 
@@ -25,5 +26,9 @@ exec('git add .');
 exec('git config user.name "Steve Sewell"');
 exec('git config user.email "sewell.steve@gmail.com"');
 exec('git commit -m "docs(docs): update gh-pages"');
-exec(`git push --force --quiet "https://${ghToken}@${repository}" master:gh-pages`);
+const encodedToken = encodeURIComponent(ghToken || '');
+const remoteUrl = `https://${encodedToken}@${repository}`;
+execFileSync('git', ['push', '--force', '--quiet', remoteUrl, 'master:gh-pages'], {
+  stdio: 'inherit',
+});
 echo('Docs deployed!!');


### PR DESCRIPTION
<!-- dd-meta {"pullId":"022373b3-1890-42b3-885d-d928f935cbeb","source":"chat","resourceId":"be29d986-133e-4151-a2c6-4292bc85798e","workflowId":"67ec0a2e-5edf-4dd4-a316-4a1af814e61e","codeChangeId":"67ec0a2e-5edf-4dd4-a316-4a1af814e61e","sourceType":"code_security_sast"} -->
## Description

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/0162d06b2eac9d61c7c00e18cc596828?query=%40status%3Aopen%20-%40vulnerability.confidence%3Alow&column=score&order=desc&panel_event_id=AwAAAZ8cx3pXV4z_-QAAABhBWjhjeDNwWEFBQmx0RlFBZ21kYTBWdVkAAAAkZjE5ZjFjY2MtOWVkMi00YTc3LWE2ZTgtZjNmM2ZiMGI3OTZkAABIWg)

This change remediates a potential command injection risk in the gh-pages publish helper by removing shell-interpreted command construction for the push step.

## Motivation (WHY)
The publish script previously interpolated environment- and repository-derived values into a shell command string for `git push`, which could allow command injection if those values were maliciously crafted.

## Changes (WHAT)
- Added `execFileSync` from Node's `child_process` module.
- Replaced the vulnerable string-based `exec(...)` call used for `git push` with `execFileSync('git', [...])` argument-array execution.
- URL-encoded `GH_TOKEN` before building the remote URL argument to avoid unsafe token characters being interpreted unexpectedly.
- Kept command execution behavior consistent by using inherited stdio.

## Testing (HOW verified)
- Ran formatter on changed files (`Format` tool / Prettier); no additional formatting changes were required.
- Ran linter automation (`Lint` tool); repository tooling could not auto-detect a linter for this file.
- Manually reviewed the diff to confirm no shell command string is constructed from untrusted input for the vulnerable push command.

_Screenshot_
Not relevant for this backend script change.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/be29d986-133e-4151-a2c6-4292bc85798e)

Comment @datadog to request changes