### PR TITLE
Fix gh-pages publish command injection

### DIFF
--- a/packages/fiddle/tools/gh-pages-publish.ts
+++ b/packages/fiddle/tools/gh-pages-publish.ts
@@ -1,5 +1,6 @@
 const { cd, exec, echo, touch } = require('shelljs');
 const { readFileSync } = require('fs');
+const { execFileSync } = require('child_process');
 const url = require('url');
 
 let repoUrl;
@@ -16,6 +17,9 @@ if (typeof pkg.repository === 'object') {
 let parsedUrl = url.parse(repoUrl);
 let repository = (parsedUrl.host || '') + (parsedUrl.path || '');
 let ghToken = process.env.GH_TOKEN;
+if (!ghToken) {
+  throw new Error('GH_TOKEN environment variable must be set');
+}
 
 echo('Deploying docs!!!');
 cd('docs');
@@ -25,5 +29,8 @@ exec('git add .');
 exec('git config user.name "Steve Sewell"');
 exec('git config user.email "sewell.steve@gmail.com"');
 exec('git commit -m "docs(docs): update gh-pages"');
-exec(`git push --force --quiet "https://${ghToken}@${repository}" master:gh-pages`);
+const remoteWithToken = `https://${ghToken}@${repository}`;
+execFileSync('git', ['push', '--force', '--quiet', remoteWithToken, 'master:gh-pages'], {
+  stdio: 'inherit',
+});
 echo('Docs deployed!!');


### PR DESCRIPTION
<!-- dd-meta {"pullId":"43db3798-1b62-40fe-8993-9372853b7024","source":"chat","resourceId":"31803507-9f1f-4853-b719-d06227a384af","workflowId":"9aeb2028-8147-4495-824a-a5e40862b626","codeChangeId":"9aeb2028-8147-4495-824a-a5e40862b626","sourceType":"code_security_sast"} -->
## Description

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/0162d06b2eac9d61c7c00e18cc596828?panel_event_id=AwAAAZ8eV2MkV4z_-QAAABhBWjhlVjJNa0FBQUNNQUMzckQ5amFwM3MAAAAkZjE5ZjFlNWEtZTA0Yi00YWNiLTkxZWItMTNmNDhlYWE3NjM5AAA7LQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MDE2MmQwNmIyZWFjOWQ2MWM3YzAwZTE4Y2M1OTY4Mjh-ZjY4YjljYThjYTBhNzk3ZWNhZDIyNTRmNzZlMTZiMzU%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fbuilder.io%22+%22Potential+command+injection%22)

Hardened the `deploy-docs` publishing script to remove shell interpolation of credential and repository values during `git push`, reducing the risk of command execution from untrusted input.

## Motivation
The previous implementation constructed a shell command string with `GH_TOKEN` and repository data. Because `shelljs.exec()` runs through a shell, shell metacharacters in those values could be interpreted as commands.

## Changes
- Replaced the dynamic `shelljs.exec()` push command with `child_process.execFileSync()` using explicit argument arrays.
- Added a fast-fail guard that throws when `GH_TOKEN` is not set.
- Kept the rest of the docs deployment flow unchanged to minimize risk and scope.

## Testing
- Reviewed the patch with `git diff -- packages/fiddle/tools/gh-pages-publish.ts` to confirm only targeted changes were made.
- Ran the repository lint automation tool; it reported no configured linter for this file (`packages/fiddle/tools/gh-pages-publish.ts` was not processed).

_Screenshot_
Not applicable (no UI changes).

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/31803507-9f1f-4853-b719-d06227a384af)

Comment @datadog to request changes