### PR TITLE
Harden gh-pages publish push command

### DIFF
--- a/plugins/async-dropdown/tools/gh-pages-publish.ts
+++ b/plugins/async-dropdown/tools/gh-pages-publish.ts
@@ -1,5 +1,6 @@
 const { cd, exec, echo, touch } = require('shelljs');
 const { readFileSync } = require('fs');
+const { execFileSync } = require('child_process');
 const url = require('url');
 
 let repoUrl;
@@ -25,5 +26,9 @@ exec('git add .');
 exec('git config user.name "Steve Sewell"');
 exec('git config user.email "sewell.steve@gmail.com"');
 exec('git commit -m "docs(docs): update gh-pages"');
-exec(`git push --force --quiet "https://${ghToken}@${repository}" master:gh-pages`);
+execFileSync(
+  'git',
+  ['push', '--force', '--quiet', `https://${ghToken}@${repository}`, 'master:gh-pages'],
+  { stdio: 'inherit' }
+);
 echo('Docs deployed!!');


### PR DESCRIPTION
<!-- dd-meta {"pullId":"cc6b8f62-9436-4dfa-ac31-5da7294a2079","source":"chat","resourceId":"3f62e300-b147-4402-a745-877d8b11cec7","workflowId":"b9733606-5ab3-41b1-8841-60755d850f1d","codeChangeId":"b9733606-5ab3-41b1-8841-60755d850f1d","sourceType":"code_security_sast"} -->
## Description

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/56878432e242d840e1028298d2d6b110?panel_event_id=AwAAAZ8fg9TW6cMztAAAABhBWjhmZzlUV0FBRDlUaHZHQ2gwWkZBYzEAAAAkZjE5ZjFmODMtZDZkYS00NmIwLWIyYmQtMWQ0NzM0NTAzNDY3AAAADg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NTY4Nzg0MzJlMjQyZDg0MGUxMDI4Mjk4ZDJkNmIxMTB-ZjY4YjljYThjYTBhNzk3ZWNhZDIyNTRmNzZlMTZiMzU%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fbuilder.io%22+%22Potential+command+injection%22)

### Motivation (WHY)
The docs publish script built a shell command with interpolated values from `GH_TOKEN` and `package.json` repository metadata. Using a shell-interpreted string here creates a command-injection risk if either value contains shell metacharacters.

### Changes (WHAT)
- Replaced the final `shelljs.exec(...)` push command with `child_process.execFileSync(...)`.
- Passed git arguments as a parameter array instead of a single shell command string.
- Kept the push target and behavior unchanged (`--force --quiet` to `master:gh-pages`).

### Testing (HOW verified)
- Verified the updated file diff to confirm only the vulnerable command execution path changed.
- Attempted to run plugin linting, but local sandbox dependencies are not installed (`tslint: not found`).

_Screenshot_
Not applicable for this CLI/script-only security fix.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/3f62e300-b147-4402-a745-877d8b11cec7)

Comment @datadog to request changes