### PR TITLE
Harden gh-pages publish command execution

### DIFF
--- a/packages/webcomponents/tools/gh-pages-publish.ts
+++ b/packages/webcomponents/tools/gh-pages-publish.ts
@@ -1,4 +1,5 @@
 const { cd, exec, echo, touch } = require('shelljs');
+const { execFileSync } = require('child_process');
 const { readFileSync } = require('fs');
 const url = require('url');
 
@@ -17,6 +18,10 @@ let parsedUrl = url.parse(repoUrl);
 let repository = (parsedUrl.host || '') + (parsedUrl.path || '');
 let ghToken = process.env.GH_TOKEN;
 
+if (!ghToken) {
+  throw new Error('GH_TOKEN environment variable is required');
+}
+
 echo('Deploying docs!!!');
 cd('docs');
 touch('.nojekyll');
@@ -25,5 +30,11 @@ exec('git add .');
 exec('git config user.name "Steve Sewell"');
 exec('git config user.email "sewell.steve@gmail.com"');
 exec('git commit -m "docs(docs): update gh-pages"');
-exec(`git push --force --quiet "https://${ghToken}@${repository}" master:gh-pages`);
+execFileSync(
+  'git',
+  ['push', '--force', '--quiet', `https://${encodeURIComponent(ghToken)}@${repository}`, 'master:gh-pages'],
+  {
+    stdio: 'inherit',
+  }
+);
 echo('Docs deployed!!');


### PR DESCRIPTION
<!-- dd-meta {"pullId":"83b18a53-0c46-4639-80d2-b76b6a8cf360","source":"chat","resourceId":"b731ad19-76da-4752-ba6e-1c40d2c87316","workflowId":"21348672-71c1-42e4-9c1e-123fa2c0084f","codeChangeId":"21348672-71c1-42e4-9c1e-123fa2c0084f","sourceType":"code_security_sast"} -->
## Description

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/9064af7eb6d7280a5bcfe2cc7bc50f02?panel_event_id=AwAAAZ8fg9qDndiQBgAAABhBWjhmZzlxREFBQ3RDSnU0RzR3OHR4N00AAAAkZjE5ZjFmODMtZjRkZC00ZTRkLWE3MDEtOTVlZGFiNzAzOTZlAAAAFQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22OTA2NGFmN2ViNmQ3MjgwYTViY2ZlMmNjN2JjNTBmMDJ-ZjY4YjljYThjYTBhNzk3ZWNhZDIyNTRmNzZlMTZiMzU%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fbuilder.io%22+%22Potential+command+injection%22)

This change hardens the docs publishing script in `packages/webcomponents/tools/gh-pages-publish.ts` to prevent command injection when building the git push command from environment and repository values.

## Motivation
The current script interpolates `GH_TOKEN` and repository data directly into a shell command string passed to `shelljs.exec`, which can allow shell interpretation of untrusted characters. This can be exploited if those values are ever manipulated in a CI or local environment.

## Changes
- Added `execFileSync` from `child_process` for the `git push` invocation.
- Replaced shell-string execution for `git push` with argument-array execution via `execFileSync(...)` to avoid shell parsing.
- Added a guard that fails fast when `GH_TOKEN` is missing.
- URL-encoded `GH_TOKEN` before embedding it in the remote URL.

## Testing
- Ran repository formatter tool (`prettier`) on changed files; no additional formatting changes were needed.
- Ran repository lint tool; it reported no configured linter for this changed file path.
- Reviewed the resulting diff to confirm only the targeted command execution path changed.

_Screenshot_
N/A (script-only change; no UI impact).

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b731ad19-76da-4752-ba6e-1c40d2c87316)

Comment @datadog to request changes