### PR TITLE
Harden gh-pages publish command execution

### DIFF
--- a/packages/widgets/tools/gh-pages-publish.ts
+++ b/packages/widgets/tools/gh-pages-publish.ts
@@ -1,4 +1,5 @@
 const { cd, exec, echo, touch } = require('shelljs');
+const { execFileSync } = require('child_process');
 const { readFileSync } = require('fs');
 const url = require('url');
 
@@ -16,6 +17,9 @@ if (typeof pkg.repository === 'object') {
 let parsedUrl = url.parse(repoUrl);
 let repository = (parsedUrl.host || '') + (parsedUrl.path || '');
 let ghToken = process.env.GH_TOKEN;
+if (!ghToken) {
+  throw new Error('GH_TOKEN environment variable is required');
+}
 
 echo('Deploying docs!!!');
 cd('docs');
@@ -25,5 +29,9 @@ exec('git add .');
 exec('git config user.name "Steve Sewell"');
 exec('git config user.email "sewell.steve@gmail.com"');
 exec('git commit -m "docs(docs): update gh-pages"');
-exec(`git push --force --quiet "https://${ghToken}@${repository}" master:gh-pages`);
+execFileSync(
+  'git',
+  ['push', '--force', '--quiet', `https://${encodeURIComponent(ghToken)}@${repository}`, 'master:gh-pages'],
+  { stdio: 'inherit' }
+);
 echo('Docs deployed!!');


### PR DESCRIPTION
<!-- dd-meta {"pullId":"846ff330-a08a-4687-a734-9131fa328fef","source":"chat","resourceId":"fc35785f-b50c-4098-8d3f-20e81213d063","workflowId":"02095952-5f87-4bee-a97f-e83cd204d0d1","codeChangeId":"02095952-5f87-4bee-a97f-e83cd204d0d1","sourceType":"code_security_sast"} -->
## Description

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/01fd2744d5b8d31561321864f8257b59?panel_event_id=AwAAAZ8fg9kilFJJ8gAAABhBWjhmZzlraUFBQTBVMVIxa0NYWWRXOGsAAAAkZjE5ZjFmODMtZjRkZC00ZTRkLWE3MDEtOTVlZGFiNzAzOTZlAAAAFw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MDFmZDI3NDRkNWI4ZDMxNTYxMzIxODY0ZjgyNTdiNTl-ZjY4YjljYThjYTBhNzk3ZWNhZDIyNTRmNzZlMTZiMzU%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fbuilder.io%22+%22Potential+command+injection%22)

Hardened the docs deployment script in packages/widgets/tools/gh-pages-publish.ts to remove shell interpolation for the git push target and prevent command injection from untrusted token/repository values.

## Motivation
The previous implementation built a shell command string with GH_TOKEN and repository data and executed it via shelljs exec. Because the command was interpreted by a shell, crafted values could trigger command injection. This change removes shell interpretation from the dynamic push arguments.

## Changes
- Added child_process.execFileSync usage for the git push call.
- Replaced the interpolated shell command with argument-based execution:
  - git push --force --quiet <remote-url> master:gh-pages
- URL-encoded GH_TOKEN before embedding it into the remote URL.
- Added an explicit runtime check that GH_TOKEN is set before attempting publish.

## Testing
- Ran repository formatter tool on modified files (prettier reported no additional changes needed).
- Ran repository lint tool; no auto-detected linter for this file.
- Attempted a TypeScript transpile check via Node; blocked because the sandbox does not have the typescript module installed.

_Screenshot_
Not applicable for this backend tooling/security fix.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/fc35785f-b50c-4098-8d3f-20e81213d063)

Comment @datadog to request changes